### PR TITLE
Удаление пассажиров

### DIFF
--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml
@@ -121,7 +121,7 @@
                 </BoxContainer>
                 <BoxContainer Orientation="Vertical">
                     <!-- Jobs -->
-                    <OptionButton Name="PreferenceUnavailableButton" />
+                    <!-- <OptionButton Name="PreferenceUnavailableButton" /> -->
                     <ScrollContainer VerticalExpand="True">
                         <BoxContainer Name="JobList" Orientation="Vertical" />
                     </ScrollContainer>

--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -388,21 +388,21 @@ namespace Content.Client.Lobby.UI
             #region Jobs
 
             TabContainer.SetTabTitle(1, Loc.GetString("humanoid-profile-editor-jobs-tab"));
+            //  Rayten-graytidegate
+            // PreferenceUnavailableButton.AddItem(
+            //     Loc.GetString("humanoid-profile-editor-preference-unavailable-stay-in-lobby-button"),
+            //     (int) PreferenceUnavailableMode.StayInLobby);
+            // PreferenceUnavailableButton.AddItem(
+            //     Loc.GetString("humanoid-profile-editor-preference-unavailable-spawn-as-overflow-button",
+            //                   ("overflowJob", Loc.GetString(SharedGameTicker.FallbackOverflowJobName))),
+            //     (int) PreferenceUnavailableMode.SpawnAsOverflow);
 
-            PreferenceUnavailableButton.AddItem(
-                Loc.GetString("humanoid-profile-editor-preference-unavailable-stay-in-lobby-button"),
-                (int) PreferenceUnavailableMode.StayInLobby);
-            PreferenceUnavailableButton.AddItem(
-                Loc.GetString("humanoid-profile-editor-preference-unavailable-spawn-as-overflow-button",
-                              ("overflowJob", Loc.GetString(SharedGameTicker.FallbackOverflowJobName))),
-                (int) PreferenceUnavailableMode.SpawnAsOverflow);
-
-            PreferenceUnavailableButton.OnItemSelected += args =>
-            {
-                PreferenceUnavailableButton.SelectId(args.Id);
-                Profile = Profile?.WithPreferenceUnavailable((PreferenceUnavailableMode) args.Id);
-                SetDirty();
-            };
+            // PreferenceUnavailableButton.OnItemSelected += args =>
+            // {
+            //     PreferenceUnavailableButton.SelectId(args.Id);
+            //     Profile = Profile?.WithPreferenceUnavailable((PreferenceUnavailableMode) args.Id);
+            //     SetDirty();
+            // };
 
             _jobCategories = new Dictionary<string, BoxContainer>();
 
@@ -779,10 +779,10 @@ namespace Content.Client.Lobby.UI
             RefreshFlavorText();
             ReloadPreview();
 
-            if (Profile != null)
-            {
-                PreferenceUnavailableButton.SelectId((int) Profile.PreferenceUnavailable);
-            }
+            // if (Profile != null)
+            // {
+            //     PreferenceUnavailableButton.SelectId((int) Profile.PreferenceUnavailable);
+            // }
         }
 
 

--- a/Content.IntegrationTests/Tests/Round/JobTest.cs
+++ b/Content.IntegrationTests/Tests/Round/JobTest.cs
@@ -18,7 +18,7 @@ namespace Content.IntegrationTests.Tests.Round;
 [TestFixture]
 public sealed class JobTest
 {
-    private static readonly ProtoId<JobPrototype> Passenger = "Passenger";
+    private static readonly ProtoId<JobPrototype> Passenger = "Janitor";
     private static readonly ProtoId<JobPrototype> Engineer = "StationEngineer";
     private static readonly ProtoId<JobPrototype> Captain = "Captain";
 

--- a/Content.Shared/GameTicking/SharedGameTicker.cs
+++ b/Content.Shared/GameTicking/SharedGameTicker.cs
@@ -19,9 +19,9 @@ namespace Content.Shared.GameTicking
         // But this is easier, and at least it isn't hardcoded.
         //TODO: Move these, they really belong in StationJobsSystem or a cvar.
         [ValidatePrototypeId<JobPrototype>]
-        public const string FallbackOverflowJob = "Passenger";
+        public const string FallbackOverflowJob = "Janitor";
 
-        public const string FallbackOverflowJobName = "job-name-passenger";
+        public const string FallbackOverflowJobName = "job-name-janitor";
 
         // TODO network.
         // Probably most useful for replays, round end info, and probably things like lobby menus.

--- a/Content.Shared/Preferences/HumanoidCharacterProfile.cs
+++ b/Content.Shared/Preferences/HumanoidCharacterProfile.cs
@@ -380,9 +380,8 @@ namespace Content.Shared.Preferences
 
         public HumanoidCharacterProfile WithPreferenceUnavailable(PreferenceUnavailableMode mode)
         {
-            return new(this) { PreferenceUnavailable = mode };
+            return new(this) { PreferenceUnavailable = PreferenceUnavailableMode.StayInLobby }; // Rayten-graytidegate
         }
-
         public HumanoidCharacterProfile WithAntagPreferences(IEnumerable<ProtoId<AntagPrototype>> antagPreferences)
         {
             return new(this)

--- a/Resources/Maps/Nonstations/meteor-arena.yml
+++ b/Resources/Maps/Nonstations/meteor-arena.yml
@@ -984,7 +984,7 @@ entities:
     - type: Transform
       pos: -0.5,-0.5
       parent: 2
-- proto: SpawnPointPassenger
+- proto: SpawnPointServiceWorker
   entities:
   - uid: 99
     components:

--- a/Resources/Prototypes/Corvax/Maps/Corvax/astra.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/astra.yml
@@ -63,7 +63,7 @@
             Reporter: [ 1, 1 ]
             ServiceWorker: [ 3, 4 ]
             Zookeeper: [ 1, 1 ]
-            Passenger: [ 1, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 1 ] # Rayten-graytidegate
             # silicon
             StationAi: [ 1, 1 ]
             Borg: [ 2, 2 ]

--- a/Resources/Prototypes/Corvax/Maps/Corvax/astra.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/astra.yml
@@ -63,7 +63,7 @@
             Reporter: [ 1, 1 ]
             ServiceWorker: [ 3, 4 ]
             Zookeeper: [ 1, 1 ]
-            Passenger: [ -1, -1 ]
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             # silicon
             StationAi: [ 1, 1 ]
             Borg: [ 2, 2 ]

--- a/Resources/Prototypes/Corvax/Maps/Corvax/astra.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/astra.yml
@@ -63,7 +63,7 @@
             Reporter: [ 1, 1 ]
             ServiceWorker: [ 3, 4 ]
             Zookeeper: [ 1, 1 ]
-            Passenger: [ 1, 1 ] # Rayten-graytidegate
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             # silicon
             StationAi: [ 1, 1 ]
             Borg: [ 2, 2 ]

--- a/Resources/Prototypes/Corvax/Maps/Corvax/astra.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/astra.yml
@@ -63,7 +63,7 @@
             Reporter: [ 1, 1 ]
             ServiceWorker: [ 3, 4 ]
             Zookeeper: [ 1, 1 ]
-            Passenger: [ 0, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 0 ] # Rayten-graytidegate
             # silicon
             StationAi: [ 1, 1 ]
             Borg: [ 2, 2 ]

--- a/Resources/Prototypes/Corvax/Maps/Corvax/astra.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/astra.yml
@@ -63,7 +63,7 @@
             Reporter: [ 1, 1 ]
             ServiceWorker: [ 3, 4 ]
             Zookeeper: [ 1, 1 ]
-            # Passenger: [ -1, -1 ] # Rayten-graytidegate
+            Passenger: [ 0, 0 ] # Rayten-graytidegate
             # silicon
             StationAi: [ 1, 1 ]
             Borg: [ 2, 2 ]

--- a/Resources/Prototypes/Corvax/Maps/Corvax/avrite.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/avrite.yml
@@ -64,7 +64,7 @@
           Reporter: [ 1, 2 ]
           ServiceWorker: [ 3, 4 ]
           Zookeeper: [ 1, 1 ]
-          Passenger: [ 1, 1 ] # Rayten-graytidegate
+          # Passenger: [ -1, -1 ] # Rayten-graytidegate
           # silicon
           StationAi: [ 1, 1 ]
           Borg: [ 2, 3 ]

--- a/Resources/Prototypes/Corvax/Maps/Corvax/avrite.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/avrite.yml
@@ -64,7 +64,7 @@
           Reporter: [ 1, 2 ]
           ServiceWorker: [ 3, 4 ]
           Zookeeper: [ 1, 1 ]
-          Passenger: [ -1, -1 ]
+          # Passenger: [ -1, -1 ] # Rayten-graytidegate
           # silicon
           StationAi: [ 1, 1 ]
           Borg: [ 2, 3 ]

--- a/Resources/Prototypes/Corvax/Maps/Corvax/avrite.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/avrite.yml
@@ -64,7 +64,7 @@
           Reporter: [ 1, 2 ]
           ServiceWorker: [ 3, 4 ]
           Zookeeper: [ 1, 1 ]
-          Passenger: [ 0, 0 ] # Rayten-graytidegate
+          Passenger: [ 1, 0 ] # Rayten-graytidegate
           # silicon
           StationAi: [ 1, 1 ]
           Borg: [ 2, 3 ]

--- a/Resources/Prototypes/Corvax/Maps/Corvax/avrite.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/avrite.yml
@@ -64,7 +64,7 @@
           Reporter: [ 1, 2 ]
           ServiceWorker: [ 3, 4 ]
           Zookeeper: [ 1, 1 ]
-          Passenger: [ 1, 0 ] # Rayten-graytidegate
+          Passenger: [ 1, 1 ] # Rayten-graytidegate
           # silicon
           StationAi: [ 1, 1 ]
           Borg: [ 2, 3 ]

--- a/Resources/Prototypes/Corvax/Maps/Corvax/avrite.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/avrite.yml
@@ -64,7 +64,7 @@
           Reporter: [ 1, 2 ]
           ServiceWorker: [ 3, 4 ]
           Zookeeper: [ 1, 1 ]
-          # Passenger: [ -1, -1 ] # Rayten-graytidegate
+          Passenger: [ 0, 0 ] # Rayten-graytidegate
           # silicon
           StationAi: [ 1, 1 ]
           Borg: [ 2, 3 ]

--- a/Resources/Prototypes/Corvax/Maps/Corvax/awesome.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/awesome.yml
@@ -60,7 +60,7 @@
             Musician: [ 1, 1 ]
             Reporter: [ 1, 1 ]
             ServiceWorker: [ 3, 3 ]
-            Passenger: [ 0, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 0 ] # Rayten-graytidegate
             # silicon
             StationAi: [ 1, 1 ]
             Borg: [ 2, 2 ]

--- a/Resources/Prototypes/Corvax/Maps/Corvax/awesome.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/awesome.yml
@@ -60,7 +60,7 @@
             Musician: [ 1, 1 ]
             Reporter: [ 1, 1 ]
             ServiceWorker: [ 3, 3 ]
-            Passenger: [ 1, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 1 ] # Rayten-graytidegate
             # silicon
             StationAi: [ 1, 1 ]
             Borg: [ 2, 2 ]

--- a/Resources/Prototypes/Corvax/Maps/Corvax/awesome.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/awesome.yml
@@ -60,7 +60,7 @@
             Musician: [ 1, 1 ]
             Reporter: [ 1, 1 ]
             ServiceWorker: [ 3, 3 ]
-            # Passenger: [ -1, -1 ] # Rayten-graytidegate
+            Passenger: [ 0, 0 ] # Rayten-graytidegate
             # silicon
             StationAi: [ 1, 1 ]
             Borg: [ 2, 2 ]

--- a/Resources/Prototypes/Corvax/Maps/Corvax/awesome.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/awesome.yml
@@ -60,7 +60,7 @@
             Musician: [ 1, 1 ]
             Reporter: [ 1, 1 ]
             ServiceWorker: [ 3, 3 ]
-            Passenger: [ -1, -1 ]
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             # silicon
             StationAi: [ 1, 1 ]
             Borg: [ 2, 2 ]

--- a/Resources/Prototypes/Corvax/Maps/Corvax/awesome.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/awesome.yml
@@ -60,7 +60,7 @@
             Musician: [ 1, 1 ]
             Reporter: [ 1, 1 ]
             ServiceWorker: [ 3, 3 ]
-            Passenger: [ 1, 1 ] # Rayten-graytidegate
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             # silicon
             StationAi: [ 1, 1 ]
             Borg: [ 2, 2 ]

--- a/Resources/Prototypes/Corvax/Maps/Corvax/cute.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/cute.yml
@@ -66,7 +66,7 @@
             Musician: [ 1, 1 ]
             Reporter: [ 1, 1 ]
             ServiceWorker: [ 2, 2 ]
-            Passenger: [ -1, -1 ]
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             # silicon
             StationAi: [ 1, 1 ]
             Borg: [ 1, 1 ]

--- a/Resources/Prototypes/Corvax/Maps/Corvax/cute.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/cute.yml
@@ -66,7 +66,7 @@
             Musician: [ 1, 1 ]
             Reporter: [ 1, 1 ]
             ServiceWorker: [ 2, 2 ]
-            Passenger: [ 1, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 1 ] # Rayten-graytidegate
             # silicon
             StationAi: [ 1, 1 ]
             Borg: [ 1, 1 ]

--- a/Resources/Prototypes/Corvax/Maps/Corvax/cute.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/cute.yml
@@ -66,7 +66,7 @@
             Musician: [ 1, 1 ]
             Reporter: [ 1, 1 ]
             ServiceWorker: [ 2, 2 ]
-            Passenger: [ 0, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 0 ] # Rayten-graytidegate
             # silicon
             StationAi: [ 1, 1 ]
             Borg: [ 1, 1 ]

--- a/Resources/Prototypes/Corvax/Maps/Corvax/cute.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/cute.yml
@@ -66,7 +66,7 @@
             Musician: [ 1, 1 ]
             Reporter: [ 1, 1 ]
             ServiceWorker: [ 2, 2 ]
-            Passenger: [ 1, 1 ] # Rayten-graytidegate
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             # silicon
             StationAi: [ 1, 1 ]
             Borg: [ 1, 1 ]

--- a/Resources/Prototypes/Corvax/Maps/Corvax/cute.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/cute.yml
@@ -66,7 +66,7 @@
             Musician: [ 1, 1 ]
             Reporter: [ 1, 1 ]
             ServiceWorker: [ 2, 2 ]
-            # Passenger: [ -1, -1 ] # Rayten-graytidegate
+            Passenger: [ 0, 0 ] # Rayten-graytidegate
             # silicon
             StationAi: [ 1, 1 ]
             Borg: [ 1, 1 ]

--- a/Resources/Prototypes/Corvax/Maps/Corvax/delta.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/delta.yml
@@ -64,7 +64,7 @@
             Reporter: [ 2, 2 ]
             ServiceWorker: [ 3, 3 ]
             Zookeeper: [ 1, 1 ]
-            Passenger: [ -1, -1 ]
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             # silicon
             StationAi: [ 1, 1 ]
             Borg: [ 2, 3 ]

--- a/Resources/Prototypes/Corvax/Maps/Corvax/delta.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/delta.yml
@@ -64,7 +64,7 @@
             Reporter: [ 2, 2 ]
             ServiceWorker: [ 3, 3 ]
             Zookeeper: [ 1, 1 ]
-            # Passenger: [ -1, -1 ] # Rayten-graytidegate
+            Passenger: [ 0, 0 ] # Rayten-graytidegate
             # silicon
             StationAi: [ 1, 1 ]
             Borg: [ 2, 3 ]

--- a/Resources/Prototypes/Corvax/Maps/Corvax/delta.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/delta.yml
@@ -64,7 +64,7 @@
             Reporter: [ 2, 2 ]
             ServiceWorker: [ 3, 3 ]
             Zookeeper: [ 1, 1 ]
-            Passenger: [ 0, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 0 ] # Rayten-graytidegate
             # silicon
             StationAi: [ 1, 1 ]
             Borg: [ 2, 3 ]

--- a/Resources/Prototypes/Corvax/Maps/Corvax/delta.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/delta.yml
@@ -64,7 +64,7 @@
             Reporter: [ 2, 2 ]
             ServiceWorker: [ 3, 3 ]
             Zookeeper: [ 1, 1 ]
-            Passenger: [ 1, 1 ] # Rayten-graytidegate
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             # silicon
             StationAi: [ 1, 1 ]
             Borg: [ 2, 3 ]

--- a/Resources/Prototypes/Corvax/Maps/Corvax/delta.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/delta.yml
@@ -64,7 +64,7 @@
             Reporter: [ 2, 2 ]
             ServiceWorker: [ 3, 3 ]
             Zookeeper: [ 1, 1 ]
-            Passenger: [ 1, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 1 ] # Rayten-graytidegate
             # silicon
             StationAi: [ 1, 1 ]
             Borg: [ 2, 3 ]

--- a/Resources/Prototypes/Corvax/Maps/Corvax/gelta.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/gelta.yml
@@ -61,4 +61,4 @@
             Musician: [ 2, 2 ]
             Reporter: [ 2, 2 ]
             ServiceWorker: [ 3, 3 ]
-            Passenger: [ 1, 1 ] # Rayten-graytidegate
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate

--- a/Resources/Prototypes/Corvax/Maps/Corvax/gelta.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/gelta.yml
@@ -61,4 +61,4 @@
             Musician: [ 2, 2 ]
             Reporter: [ 2, 2 ]
             ServiceWorker: [ 3, 3 ]
-            Passenger: [ 0, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 0 ] # Rayten-graytidegate

--- a/Resources/Prototypes/Corvax/Maps/Corvax/gelta.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/gelta.yml
@@ -61,4 +61,4 @@
             Musician: [ 2, 2 ]
             Reporter: [ 2, 2 ]
             ServiceWorker: [ 3, 3 ]
-            Passenger: [ 1, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 1 ] # Rayten-graytidegate

--- a/Resources/Prototypes/Corvax/Maps/Corvax/gelta.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/gelta.yml
@@ -61,4 +61,4 @@
             Musician: [ 2, 2 ]
             Reporter: [ 2, 2 ]
             ServiceWorker: [ 3, 3 ]
-            # Passenger: [ -1, -1 ] # Rayten-graytidegate
+            Passenger: [ 0, 0 ] # Rayten-graytidegate

--- a/Resources/Prototypes/Corvax/Maps/Corvax/gelta.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/gelta.yml
@@ -61,4 +61,4 @@
             Musician: [ 2, 2 ]
             Reporter: [ 2, 2 ]
             ServiceWorker: [ 3, 3 ]
-            Passenger: [ -1, -1 ]
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate

--- a/Resources/Prototypes/Corvax/Maps/Corvax/glacier.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/glacier.yml
@@ -75,7 +75,7 @@
             Reporter: [ 1, 2 ]
             ServiceWorker: [ 2, 3 ]
             Zookeeper: [ 1, 1 ]
-            Passenger: [ 1, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 1 ] # Rayten-graytidegate
             # silicon
             StationAi: [ 1, 1 ]
             Borg: [ 2, 3 ]

--- a/Resources/Prototypes/Corvax/Maps/Corvax/glacier.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/glacier.yml
@@ -75,7 +75,7 @@
             Reporter: [ 1, 2 ]
             ServiceWorker: [ 2, 3 ]
             Zookeeper: [ 1, 1 ]
-            Passenger: [ -1, -1 ]
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             # silicon
             StationAi: [ 1, 1 ]
             Borg: [ 2, 3 ]

--- a/Resources/Prototypes/Corvax/Maps/Corvax/glacier.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/glacier.yml
@@ -75,7 +75,7 @@
             Reporter: [ 1, 2 ]
             ServiceWorker: [ 2, 3 ]
             Zookeeper: [ 1, 1 ]
-            Passenger: [ 1, 1 ] # Rayten-graytidegate
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             # silicon
             StationAi: [ 1, 1 ]
             Borg: [ 2, 3 ]

--- a/Resources/Prototypes/Corvax/Maps/Corvax/glacier.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/glacier.yml
@@ -75,7 +75,7 @@
             Reporter: [ 1, 2 ]
             ServiceWorker: [ 2, 3 ]
             Zookeeper: [ 1, 1 ]
-            # Passenger: [ -1, -1 ] # Rayten-graytidegate
+            Passenger: [ 0, 0 ] # Rayten-graytidegate
             # silicon
             StationAi: [ 1, 1 ]
             Borg: [ 2, 3 ]

--- a/Resources/Prototypes/Corvax/Maps/Corvax/glacier.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/glacier.yml
@@ -75,7 +75,7 @@
             Reporter: [ 1, 2 ]
             ServiceWorker: [ 2, 3 ]
             Zookeeper: [ 1, 1 ]
-            Passenger: [ 0, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 0 ] # Rayten-graytidegate
             # silicon
             StationAi: [ 1, 1 ]
             Borg: [ 2, 3 ]

--- a/Resources/Prototypes/Corvax/Maps/Corvax/ishimura.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/ishimura.yml
@@ -61,7 +61,7 @@
             Librarian: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
-            # Passenger: [ -1, -1 ] # Rayten-graytidegate
+            Passenger: [ 0, 0 ] # Rayten-graytidegate
             ServiceWorker: [ 3, 3 ]
             Reporter: [ 1, 1 ]
             # silicon

--- a/Resources/Prototypes/Corvax/Maps/Corvax/ishimura.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/ishimura.yml
@@ -61,7 +61,7 @@
             Librarian: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
-            Passenger: [ -1, -1 ]
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             ServiceWorker: [ 3, 3 ]
             Reporter: [ 1, 1 ]
             # silicon

--- a/Resources/Prototypes/Corvax/Maps/Corvax/ishimura.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/ishimura.yml
@@ -61,7 +61,7 @@
             Librarian: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
-            Passenger: [ 0, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 0 ] # Rayten-graytidegate
             ServiceWorker: [ 3, 3 ]
             Reporter: [ 1, 1 ]
             # silicon

--- a/Resources/Prototypes/Corvax/Maps/Corvax/ishimura.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/ishimura.yml
@@ -61,7 +61,7 @@
             Librarian: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
-            Passenger: [ 1, 1 ] # Rayten-graytidegate
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             ServiceWorker: [ 3, 3 ]
             Reporter: [ 1, 1 ]
             # silicon

--- a/Resources/Prototypes/Corvax/Maps/Corvax/ishimura.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/ishimura.yml
@@ -61,7 +61,7 @@
             Librarian: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
-            Passenger: [ 1, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 1 ] # Rayten-graytidegate
             ServiceWorker: [ 3, 3 ]
             Reporter: [ 1, 1 ]
             # silicon

--- a/Resources/Prototypes/Corvax/Maps/Corvax/maus.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/maus.yml
@@ -64,7 +64,7 @@
             Musician: [ 1, 1 ]
             Reporter: [ 1, 1 ]
             ServiceWorker: [ 2, 2 ]
-            Passenger: [ -1, -1 ]
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             # silicon
             StationAi: [ 1, 1 ]
             Borg: [ 1, 1 ]

--- a/Resources/Prototypes/Corvax/Maps/Corvax/maus.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/maus.yml
@@ -64,7 +64,7 @@
             Musician: [ 1, 1 ]
             Reporter: [ 1, 1 ]
             ServiceWorker: [ 2, 2 ]
-            Passenger: [ 1, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 1 ] # Rayten-graytidegate
             # silicon
             StationAi: [ 1, 1 ]
             Borg: [ 1, 1 ]

--- a/Resources/Prototypes/Corvax/Maps/Corvax/maus.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/maus.yml
@@ -64,7 +64,7 @@
             Musician: [ 1, 1 ]
             Reporter: [ 1, 1 ]
             ServiceWorker: [ 2, 2 ]
-            Passenger: [ 0, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 0 ] # Rayten-graytidegate
             # silicon
             StationAi: [ 1, 1 ]
             Borg: [ 1, 1 ]

--- a/Resources/Prototypes/Corvax/Maps/Corvax/maus.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/maus.yml
@@ -64,7 +64,7 @@
             Musician: [ 1, 1 ]
             Reporter: [ 1, 1 ]
             ServiceWorker: [ 2, 2 ]
-            Passenger: [ 1, 1 ] # Rayten-graytidegate
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             # silicon
             StationAi: [ 1, 1 ]
             Borg: [ 1, 1 ]

--- a/Resources/Prototypes/Corvax/Maps/Corvax/maus.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/maus.yml
@@ -64,7 +64,7 @@
             Musician: [ 1, 1 ]
             Reporter: [ 1, 1 ]
             ServiceWorker: [ 2, 2 ]
-            # Passenger: [ -1, -1 ] # Rayten-graytidegate
+            Passenger: [ 0, 0 ] # Rayten-graytidegate
             # silicon
             StationAi: [ 1, 1 ]
             Borg: [ 1, 1 ]

--- a/Resources/Prototypes/Corvax/Maps/Corvax/outpost.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/outpost.yml
@@ -61,7 +61,7 @@
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
             ServiceWorker: [ 2, 2 ]
-            Passenger: [ 1, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 1 ] # Rayten-graytidegate
             # silicon
             Borg: [ 1, 1 ]
             StationAi: [ 1, 1 ]

--- a/Resources/Prototypes/Corvax/Maps/Corvax/outpost.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/outpost.yml
@@ -61,7 +61,7 @@
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
             ServiceWorker: [ 2, 2 ]
-            Passenger: [ 1, 1 ] # Rayten-graytidegate
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             # silicon
             Borg: [ 1, 1 ]
             StationAi: [ 1, 1 ]

--- a/Resources/Prototypes/Corvax/Maps/Corvax/outpost.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/outpost.yml
@@ -61,7 +61,7 @@
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
             ServiceWorker: [ 2, 2 ]
-            Passenger: [ 0, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 0 ] # Rayten-graytidegate
             # silicon
             Borg: [ 1, 1 ]
             StationAi: [ 1, 1 ]

--- a/Resources/Prototypes/Corvax/Maps/Corvax/outpost.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/outpost.yml
@@ -61,7 +61,7 @@
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
             ServiceWorker: [ 2, 2 ]
-            Passenger: [ -1, -1 ]
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             # silicon
             Borg: [ 1, 1 ]
             StationAi: [ 1, 1 ]

--- a/Resources/Prototypes/Corvax/Maps/Corvax/outpost.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/outpost.yml
@@ -61,7 +61,7 @@
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]
             ServiceWorker: [ 2, 2 ]
-            # Passenger: [ -1, -1 ] # Rayten-graytidegate
+            Passenger: [ 0, 0 ] # Rayten-graytidegate
             # silicon
             Borg: [ 1, 1 ]
             StationAi: [ 1, 1 ]

--- a/Resources/Prototypes/Corvax/Maps/Corvax/paper.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/paper.yml
@@ -63,7 +63,7 @@
             Reporter: [ 1, 1 ]
             ServiceWorker: [ 3, 3 ]
             Zookeeper: [ 1, 1 ]
-            Passenger: [ 0, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 0 ] # Rayten-graytidegate
             #silicon
             StationAi: [ 1, 1 ]
             Borg: [ 3, 3 ]

--- a/Resources/Prototypes/Corvax/Maps/Corvax/paper.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/paper.yml
@@ -63,7 +63,7 @@
             Reporter: [ 1, 1 ]
             ServiceWorker: [ 3, 3 ]
             Zookeeper: [ 1, 1 ]
-            Passenger: [ -1, -1 ]
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             #silicon
             StationAi: [ 1, 1 ]
             Borg: [ 3, 3 ]

--- a/Resources/Prototypes/Corvax/Maps/Corvax/paper.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/paper.yml
@@ -63,7 +63,7 @@
             Reporter: [ 1, 1 ]
             ServiceWorker: [ 3, 3 ]
             Zookeeper: [ 1, 1 ]
-            # Passenger: [ -1, -1 ] # Rayten-graytidegate
+            Passenger: [ 0, 0 ] # Rayten-graytidegate
             #silicon
             StationAi: [ 1, 1 ]
             Borg: [ 3, 3 ]

--- a/Resources/Prototypes/Corvax/Maps/Corvax/paper.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/paper.yml
@@ -63,7 +63,7 @@
             Reporter: [ 1, 1 ]
             ServiceWorker: [ 3, 3 ]
             Zookeeper: [ 1, 1 ]
-            Passenger: [ 1, 1 ] # Rayten-graytidegate
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             #silicon
             StationAi: [ 1, 1 ]
             Borg: [ 3, 3 ]

--- a/Resources/Prototypes/Corvax/Maps/Corvax/paper.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/paper.yml
@@ -63,7 +63,7 @@
             Reporter: [ 1, 1 ]
             ServiceWorker: [ 3, 3 ]
             Zookeeper: [ 1, 1 ]
-            Passenger: [ 1, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 1 ] # Rayten-graytidegate
             #silicon
             StationAi: [ 1, 1 ]
             Borg: [ 3, 3 ]

--- a/Resources/Prototypes/Corvax/Maps/Corvax/pearl.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/pearl.yml
@@ -63,7 +63,7 @@
             Mime: [ 1, 1 ]
             Musician: [ 2, 2 ]
             ServiceWorker: [ 2, 2 ]
-            Passenger: [ 0, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 0 ] # Rayten-graytidegate
             Reporter: [ 1, 1 ]
             # silicon
             Borg: [ 1, 1 ]

--- a/Resources/Prototypes/Corvax/Maps/Corvax/pearl.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/pearl.yml
@@ -63,7 +63,7 @@
             Mime: [ 1, 1 ]
             Musician: [ 2, 2 ]
             ServiceWorker: [ 2, 2 ]
-            # Passenger: [ -1, -1 ] # Rayten-graytidegate
+            Passenger: [ 0, 0 ] # Rayten-graytidegate
             Reporter: [ 1, 1 ]
             # silicon
             Borg: [ 1, 1 ]

--- a/Resources/Prototypes/Corvax/Maps/Corvax/pearl.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/pearl.yml
@@ -63,7 +63,7 @@
             Mime: [ 1, 1 ]
             Musician: [ 2, 2 ]
             ServiceWorker: [ 2, 2 ]
-            Passenger: [ 1, 1 ] # Rayten-graytidegate
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             Reporter: [ 1, 1 ]
             # silicon
             Borg: [ 1, 1 ]

--- a/Resources/Prototypes/Corvax/Maps/Corvax/pearl.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/pearl.yml
@@ -63,7 +63,7 @@
             Mime: [ 1, 1 ]
             Musician: [ 2, 2 ]
             ServiceWorker: [ 2, 2 ]
-            Passenger: [ 1, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 1 ] # Rayten-graytidegate
             Reporter: [ 1, 1 ]
             # silicon
             Borg: [ 1, 1 ]

--- a/Resources/Prototypes/Corvax/Maps/Corvax/pearl.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/pearl.yml
@@ -63,7 +63,7 @@
             Mime: [ 1, 1 ]
             Musician: [ 2, 2 ]
             ServiceWorker: [ 2, 2 ]
-            Passenger: [ -1, -1 ]
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             Reporter: [ 1, 1 ]
             # silicon
             Borg: [ 1, 1 ]

--- a/Resources/Prototypes/Corvax/Maps/Corvax/pilgrim.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/pilgrim.yml
@@ -64,7 +64,7 @@
             Reporter: [ 2, 2 ]
             ServiceWorker: [ 3, 3 ]
             Zookeeper: [ 1, 1 ]
-            # Passenger: [ -1, -1 ] # Rayten-graytidegate
+            Passenger: [ 0, 0 ] # Rayten-graytidegate
             # silicon
             StationAi: [ 1, 1 ]
             Borg: [ 1, 1 ]

--- a/Resources/Prototypes/Corvax/Maps/Corvax/pilgrim.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/pilgrim.yml
@@ -64,7 +64,7 @@
             Reporter: [ 2, 2 ]
             ServiceWorker: [ 3, 3 ]
             Zookeeper: [ 1, 1 ]
-            Passenger: [ 1, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 1 ] # Rayten-graytidegate
             # silicon
             StationAi: [ 1, 1 ]
             Borg: [ 1, 1 ]

--- a/Resources/Prototypes/Corvax/Maps/Corvax/pilgrim.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/pilgrim.yml
@@ -64,7 +64,7 @@
             Reporter: [ 2, 2 ]
             ServiceWorker: [ 3, 3 ]
             Zookeeper: [ 1, 1 ]
-            Passenger: [ 1, 1 ] # Rayten-graytidegate
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             # silicon
             StationAi: [ 1, 1 ]
             Borg: [ 1, 1 ]

--- a/Resources/Prototypes/Corvax/Maps/Corvax/pilgrim.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/pilgrim.yml
@@ -64,7 +64,7 @@
             Reporter: [ 2, 2 ]
             ServiceWorker: [ 3, 3 ]
             Zookeeper: [ 1, 1 ]
-            Passenger: [ 0, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 0 ] # Rayten-graytidegate
             # silicon
             StationAi: [ 1, 1 ]
             Borg: [ 1, 1 ]

--- a/Resources/Prototypes/Corvax/Maps/Corvax/pilgrim.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/pilgrim.yml
@@ -64,7 +64,7 @@
             Reporter: [ 2, 2 ]
             ServiceWorker: [ 3, 3 ]
             Zookeeper: [ 1, 1 ]
-            Passenger: [ -1, -1 ]
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             # silicon
             StationAi: [ 1, 1 ]
             Borg: [ 1, 1 ]

--- a/Resources/Prototypes/Corvax/Maps/Corvax/silly.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/silly.yml
@@ -64,7 +64,7 @@
             Musician: [ 1, 1 ]
             Reporter: [ 1, 1 ]
             ServiceWorker: [ 2, 2 ]
-            # Passenger: [ -1, -1 ] # Rayten-graytidegate
+            Passenger: [ 0, 0 ] # Rayten-graytidegate
             # silicon
             Borg: [ 1, 1 ]
         - type: StationGoal

--- a/Resources/Prototypes/Corvax/Maps/Corvax/silly.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/silly.yml
@@ -64,7 +64,7 @@
             Musician: [ 1, 1 ]
             Reporter: [ 1, 1 ]
             ServiceWorker: [ 2, 2 ]
-            Passenger: [ 0, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 0 ] # Rayten-graytidegate
             # silicon
             Borg: [ 1, 1 ]
         - type: StationGoal

--- a/Resources/Prototypes/Corvax/Maps/Corvax/silly.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/silly.yml
@@ -64,7 +64,7 @@
             Musician: [ 1, 1 ]
             Reporter: [ 1, 1 ]
             ServiceWorker: [ 2, 2 ]
-            Passenger: [ 1, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 1 ] # Rayten-graytidegate
             # silicon
             Borg: [ 1, 1 ]
         - type: StationGoal

--- a/Resources/Prototypes/Corvax/Maps/Corvax/silly.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/silly.yml
@@ -64,7 +64,7 @@
             Musician: [ 1, 1 ]
             Reporter: [ 1, 1 ]
             ServiceWorker: [ 2, 2 ]
-            Passenger: [ -1, -1 ]
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             # silicon
             Borg: [ 1, 1 ]
         - type: StationGoal

--- a/Resources/Prototypes/Corvax/Maps/Corvax/silly.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/silly.yml
@@ -64,7 +64,7 @@
             Musician: [ 1, 1 ]
             Reporter: [ 1, 1 ]
             ServiceWorker: [ 2, 2 ]
-            Passenger: [ 1, 1 ] # Rayten-graytidegate
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             # silicon
             Borg: [ 1, 1 ]
         - type: StationGoal

--- a/Resources/Prototypes/Corvax/Maps/Corvax/split.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/split.yml
@@ -28,7 +28,7 @@
           availableJobs:
             # service
             HeadOfPersonnel: [ 1, 1 ]
-            # Passenger: [ -1, -1 ] # Rayten-graytidegate
+            Passenger: [ 0, 0 ] # Rayten-graytidegate
             ServiceWorker: [ 1, 2 ]
             Bartender: [ 1, 1 ]
             Botanist: [ 2, 2 ]
@@ -91,7 +91,7 @@
           availableJobs:
             # service
             HeadOfPersonnel: [ 1, 1 ]
-            # Passenger: [ -1, -1 ] # Rayten-graytidegate
+            Passenger: [ 0, 0 ] # Rayten-graytidegate
             ServiceWorker: [ 1, 1 ]
             Bartender: [ 1, 1 ]
             Botanist: [ 1, 1 ]
@@ -151,7 +151,7 @@
           availableJobs:
             # service
             HeadOfPersonnel: [ 1, 1 ]
-            # Passenger: [ -1, -1 ] # Rayten-graytidegate
+            Passenger: [ 0, 0 ] # Rayten-graytidegate
             ServiceWorker: [ 1, 1 ]
             Bartender: [ 1, 1 ]
             Botanist: [ 1, 1 ]

--- a/Resources/Prototypes/Corvax/Maps/Corvax/split.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/split.yml
@@ -28,7 +28,7 @@
           availableJobs:
             # service
             HeadOfPersonnel: [ 1, 1 ]
-            Passenger: [ 1, 1 ] # Rayten-graytidegate
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             ServiceWorker: [ 1, 2 ]
             Bartender: [ 1, 1 ]
             Botanist: [ 2, 2 ]
@@ -91,7 +91,7 @@
           availableJobs:
             # service
             HeadOfPersonnel: [ 1, 1 ]
-            Passenger: [ 1, 1 ] # Rayten-graytidegate
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             ServiceWorker: [ 1, 1 ]
             Bartender: [ 1, 1 ]
             Botanist: [ 1, 1 ]
@@ -151,7 +151,7 @@
           availableJobs:
             # service
             HeadOfPersonnel: [ 1, 1 ]
-            Passenger: [ 1, 1 ] # Rayten-graytidegate
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             ServiceWorker: [ 1, 1 ]
             Bartender: [ 1, 1 ]
             Botanist: [ 1, 1 ]

--- a/Resources/Prototypes/Corvax/Maps/Corvax/split.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/split.yml
@@ -28,7 +28,7 @@
           availableJobs:
             # service
             HeadOfPersonnel: [ 1, 1 ]
-            Passenger: [ 0, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 0 ] # Rayten-graytidegate
             ServiceWorker: [ 1, 2 ]
             Bartender: [ 1, 1 ]
             Botanist: [ 2, 2 ]
@@ -91,7 +91,7 @@
           availableJobs:
             # service
             HeadOfPersonnel: [ 1, 1 ]
-            Passenger: [ 0, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 0 ] # Rayten-graytidegate
             ServiceWorker: [ 1, 1 ]
             Bartender: [ 1, 1 ]
             Botanist: [ 1, 1 ]
@@ -151,7 +151,7 @@
           availableJobs:
             # service
             HeadOfPersonnel: [ 1, 1 ]
-            Passenger: [ 0, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 0 ] # Rayten-graytidegate
             ServiceWorker: [ 1, 1 ]
             Bartender: [ 1, 1 ]
             Botanist: [ 1, 1 ]

--- a/Resources/Prototypes/Corvax/Maps/Corvax/split.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/split.yml
@@ -28,7 +28,7 @@
           availableJobs:
             # service
             HeadOfPersonnel: [ 1, 1 ]
-            Passenger: [ 1, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 1 ] # Rayten-graytidegate
             ServiceWorker: [ 1, 2 ]
             Bartender: [ 1, 1 ]
             Botanist: [ 2, 2 ]
@@ -91,7 +91,7 @@
           availableJobs:
             # service
             HeadOfPersonnel: [ 1, 1 ]
-            Passenger: [ 1, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 1 ] # Rayten-graytidegate
             ServiceWorker: [ 1, 1 ]
             Bartender: [ 1, 1 ]
             Botanist: [ 1, 1 ]
@@ -151,7 +151,7 @@
           availableJobs:
             # service
             HeadOfPersonnel: [ 1, 1 ]
-            Passenger: [ 1, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 1 ] # Rayten-graytidegate
             ServiceWorker: [ 1, 1 ]
             Bartender: [ 1, 1 ]
             Botanist: [ 1, 1 ]

--- a/Resources/Prototypes/Corvax/Maps/Corvax/split.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/split.yml
@@ -28,7 +28,7 @@
           availableJobs:
             # service
             HeadOfPersonnel: [ 1, 1 ]
-            Passenger: [ -1, -1 ]
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             ServiceWorker: [ 1, 2 ]
             Bartender: [ 1, 1 ]
             Botanist: [ 2, 2 ]
@@ -91,7 +91,7 @@
           availableJobs:
             # service
             HeadOfPersonnel: [ 1, 1 ]
-            Passenger: [ -1, -1 ]
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             ServiceWorker: [ 1, 1 ]
             Bartender: [ 1, 1 ]
             Botanist: [ 1, 1 ]
@@ -151,7 +151,7 @@
           availableJobs:
             # service
             HeadOfPersonnel: [ 1, 1 ]
-            Passenger: [ -1, -1 ]
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             ServiceWorker: [ 1, 1 ]
             Bartender: [ 1, 1 ]
             Botanist: [ 1, 1 ]

--- a/Resources/Prototypes/Corvax/Maps/Corvax/terra.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/terra.yml
@@ -75,7 +75,7 @@
             Reporter: [ 1, 1 ]
             ServiceWorker: [ 1, 1 ]
             Zookeeper: [ 1, 1 ]
-            Passenger: [ 1, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 1 ] # Rayten-graytidegate
             # silicon
             Borg: [ 1, 1 ]
         - type: StationGoal

--- a/Resources/Prototypes/Corvax/Maps/Corvax/terra.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/terra.yml
@@ -75,7 +75,7 @@
             Reporter: [ 1, 1 ]
             ServiceWorker: [ 1, 1 ]
             Zookeeper: [ 1, 1 ]
-            # Passenger: [ -1, -1 ] # Rayten-graytidegate
+            Passenger: [ 0, 0 ] # Rayten-graytidegate
             # silicon
             Borg: [ 1, 1 ]
         - type: StationGoal

--- a/Resources/Prototypes/Corvax/Maps/Corvax/terra.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/terra.yml
@@ -75,7 +75,7 @@
             Reporter: [ 1, 1 ]
             ServiceWorker: [ 1, 1 ]
             Zookeeper: [ 1, 1 ]
-            Passenger: [ 1, 1 ] # Rayten-graytidegate
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             # silicon
             Borg: [ 1, 1 ]
         - type: StationGoal

--- a/Resources/Prototypes/Corvax/Maps/Corvax/terra.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/terra.yml
@@ -75,7 +75,7 @@
             Reporter: [ 1, 1 ]
             ServiceWorker: [ 1, 1 ]
             Zookeeper: [ 1, 1 ]
-            Passenger: [ -1, -1 ]
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             # silicon
             Borg: [ 1, 1 ]
         - type: StationGoal

--- a/Resources/Prototypes/Corvax/Maps/Corvax/terra.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/terra.yml
@@ -75,7 +75,7 @@
             Reporter: [ 1, 1 ]
             ServiceWorker: [ 1, 1 ]
             Zookeeper: [ 1, 1 ]
-            Passenger: [ 0, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 0 ] # Rayten-graytidegate
             # silicon
             Borg: [ 1, 1 ]
         - type: StationGoal

--- a/Resources/Prototypes/Corvax/Maps/Corvax/tushkan.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/tushkan.yml
@@ -64,7 +64,7 @@
             Musician: [ 1, 1 ]
             Reporter: [ 1, 1 ]
             ServiceWorker: [ 2, 2 ]
-            Passenger: [ -1, -1 ]
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             # silicon
             StationAi: [ 1, 1 ]
             Borg: [ 1, 1 ]

--- a/Resources/Prototypes/Corvax/Maps/Corvax/tushkan.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/tushkan.yml
@@ -64,7 +64,7 @@
             Musician: [ 1, 1 ]
             Reporter: [ 1, 1 ]
             ServiceWorker: [ 2, 2 ]
-            Passenger: [ 1, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 1 ] # Rayten-graytidegate
             # silicon
             StationAi: [ 1, 1 ]
             Borg: [ 1, 1 ]

--- a/Resources/Prototypes/Corvax/Maps/Corvax/tushkan.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/tushkan.yml
@@ -64,7 +64,7 @@
             Musician: [ 1, 1 ]
             Reporter: [ 1, 1 ]
             ServiceWorker: [ 2, 2 ]
-            Passenger: [ 0, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 0 ] # Rayten-graytidegate
             # silicon
             StationAi: [ 1, 1 ]
             Borg: [ 1, 1 ]

--- a/Resources/Prototypes/Corvax/Maps/Corvax/tushkan.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/tushkan.yml
@@ -64,7 +64,7 @@
             Musician: [ 1, 1 ]
             Reporter: [ 1, 1 ]
             ServiceWorker: [ 2, 2 ]
-            Passenger: [ 1, 1 ] # Rayten-graytidegate
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             # silicon
             StationAi: [ 1, 1 ]
             Borg: [ 1, 1 ]

--- a/Resources/Prototypes/Corvax/Maps/Corvax/tushkan.yml
+++ b/Resources/Prototypes/Corvax/Maps/Corvax/tushkan.yml
@@ -64,7 +64,7 @@
             Musician: [ 1, 1 ]
             Reporter: [ 1, 1 ]
             ServiceWorker: [ 2, 2 ]
-            # Passenger: [ -1, -1 ] # Rayten-graytidegate
+            Passenger: [ 0, 0 ] # Rayten-graytidegate
             # silicon
             StationAi: [ 1, 1 ]
             Borg: [ 1, 1 ]

--- a/Resources/Prototypes/Entities/Markers/Spawners/jobs.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/jobs.yml
@@ -82,8 +82,8 @@
   parent: SpawnPointJobBase
   name: passenger
   components:
-  - type: SpawnPoint
-    job_id: Passenger
+  # - type: SpawnPoint
+  #   job_id: Passenger
   - type: Sprite
     layers:
       - state: green

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -326,6 +326,18 @@
         #sound: "/Audio/Ambience/Antag/wizard_start.ogg"
       # TODO: WizardComp as needed
       components:
+      - type: Skill
+        RangeWeaponLevel: 2
+        MeleeWeaponLevel: 2
+        MedicineLevel: 2
+        ChemistryLevel: 0
+        EngineeringLevel: 1
+        BuildingLevel: 2
+        ResearchLevel: 0
+        Piloting: true
+        MusInstruments: true
+        Botany: false
+        Bureaucracy: true
       - type: NpcFactionMember
         factions:
         - Wizard
@@ -335,6 +347,8 @@
         - NamesWizardLast
       mindRoles:
       - MindRoleWizard
+
+
 # Vanilla Starts
 - type: entity
   parent: BaseGameRule

--- a/Resources/Prototypes/Maps/amber.yml
+++ b/Resources/Prototypes/Maps/amber.yml
@@ -59,7 +59,7 @@
           SalvageSpecialist: [ 3, 3 ]
           CargoTechnician: [ 3, 4 ]
           #civilian
-          Passenger: [ 1, 0 ] # Rayten-graytidegate
+          Passenger: [ 1, 1 ] # Rayten-graytidegate
           Clown: [ 1, 1 ]
           Mime: [ 1, 1 ]
           Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/amber.yml
+++ b/Resources/Prototypes/Maps/amber.yml
@@ -59,7 +59,7 @@
           SalvageSpecialist: [ 3, 3 ]
           CargoTechnician: [ 3, 4 ]
           #civilian
-          # Passenger: [ -1, -1 ] # Rayten-graytidegate
+          Passenger: [ 0, 0 ] # Rayten-graytidegate
           Clown: [ 1, 1 ]
           Mime: [ 1, 1 ]
           Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/amber.yml
+++ b/Resources/Prototypes/Maps/amber.yml
@@ -59,7 +59,7 @@
           SalvageSpecialist: [ 3, 3 ]
           CargoTechnician: [ 3, 4 ]
           #civilian
-          Passenger: [ 0, 0 ] # Rayten-graytidegate
+          Passenger: [ 1, 0 ] # Rayten-graytidegate
           Clown: [ 1, 1 ]
           Mime: [ 1, 1 ]
           Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/amber.yml
+++ b/Resources/Prototypes/Maps/amber.yml
@@ -59,7 +59,7 @@
           SalvageSpecialist: [ 3, 3 ]
           CargoTechnician: [ 3, 4 ]
           #civilian
-          Passenger: [ -1, -1 ]
+          # Passenger: [ -1, -1 ] # Rayten-graytidegate
           Clown: [ 1, 1 ]
           Mime: [ 1, 1 ]
           Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/amber.yml
+++ b/Resources/Prototypes/Maps/amber.yml
@@ -59,7 +59,7 @@
           SalvageSpecialist: [ 3, 3 ]
           CargoTechnician: [ 3, 4 ]
           #civilian
-          Passenger: [ 1, 1 ] # Rayten-graytidegate
+          # Passenger: [ -1, -1 ] # Rayten-graytidegate
           Clown: [ 1, 1 ]
           Mime: [ 1, 1 ]
           Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/arenas.yml
+++ b/Resources/Prototypes/Maps/arenas.yml
@@ -11,4 +11,4 @@
           mapNameTemplate: "Meteor Arena"
         - type: StationJobs
           availableJobs:
-            Passenger: [ -1, -1 ]
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate

--- a/Resources/Prototypes/Maps/arenas.yml
+++ b/Resources/Prototypes/Maps/arenas.yml
@@ -11,4 +11,4 @@
           mapNameTemplate: "Meteor Arena"
         - type: StationJobs
           availableJobs:
-            # Passenger: [ -1, -1 ] # Rayten-graytidegate
+            Passenger: [ -1, -1 ]

--- a/Resources/Prototypes/Maps/arenas.yml
+++ b/Resources/Prototypes/Maps/arenas.yml
@@ -11,4 +11,5 @@
           mapNameTemplate: "Meteor Arena"
         - type: StationJobs
           availableJobs:
-            Passenger: [ -1, -1 ]
+            ServiceWorker: [ -1, -1 ] # Rayten-graytidegate
+ 

--- a/Resources/Prototypes/Maps/bagel.yml
+++ b/Resources/Prototypes/Maps/bagel.yml
@@ -55,7 +55,7 @@
             SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 3, 3 ]
             #civilian
-            # Passenger: [ -1, -1 ] # Rayten-graytidegate
+            Passenger: [ 0, 0 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/bagel.yml
+++ b/Resources/Prototypes/Maps/bagel.yml
@@ -55,7 +55,7 @@
             SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 3, 3 ]
             #civilian
-            Passenger: [ -1, -1 ]
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/bagel.yml
+++ b/Resources/Prototypes/Maps/bagel.yml
@@ -55,7 +55,7 @@
             SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 3, 3 ]
             #civilian
-            Passenger: [ 1, 1 ] # Rayten-graytidegate
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/bagel.yml
+++ b/Resources/Prototypes/Maps/bagel.yml
@@ -55,7 +55,7 @@
             SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 3, 3 ]
             #civilian
-            Passenger: [ 0, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 0 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/bagel.yml
+++ b/Resources/Prototypes/Maps/bagel.yml
@@ -55,7 +55,7 @@
             SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 3, 3 ]
             #civilian
-            Passenger: [ 1, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 1 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/box.yml
+++ b/Resources/Prototypes/Maps/box.yml
@@ -56,7 +56,7 @@
             SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 3, 3 ]
             #civilian
-            Passenger: [ 1, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 1 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/box.yml
+++ b/Resources/Prototypes/Maps/box.yml
@@ -56,7 +56,7 @@
             SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 3, 3 ]
             #civilian
-            # Passenger: [ -1, -1 ] # Rayten-graytidegate
+            Passenger: [ 0, 0 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/box.yml
+++ b/Resources/Prototypes/Maps/box.yml
@@ -56,7 +56,7 @@
             SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 3, 3 ]
             #civilian
-            Passenger: [ -1, -1 ]
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/box.yml
+++ b/Resources/Prototypes/Maps/box.yml
@@ -56,7 +56,7 @@
             SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 3, 3 ]
             #civilian
-            Passenger: [ 1, 1 ] # Rayten-graytidegate
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/box.yml
+++ b/Resources/Prototypes/Maps/box.yml
@@ -56,7 +56,7 @@
             SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 3, 3 ]
             #civilian
-            Passenger: [ 0, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 0 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/cluster.yml
+++ b/Resources/Prototypes/Maps/cluster.yml
@@ -54,7 +54,7 @@
             SalvageSpecialist: [ 2, 2 ]
             CargoTechnician: [ 2, 2 ]
             #civillian
-            Passenger: [ 1, 1 ] # Rayten-graytidegate
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/cluster.yml
+++ b/Resources/Prototypes/Maps/cluster.yml
@@ -54,7 +54,7 @@
             SalvageSpecialist: [ 2, 2 ]
             CargoTechnician: [ 2, 2 ]
             #civillian
-            Passenger: [ 0, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 0 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/cluster.yml
+++ b/Resources/Prototypes/Maps/cluster.yml
@@ -54,7 +54,7 @@
             SalvageSpecialist: [ 2, 2 ]
             CargoTechnician: [ 2, 2 ]
             #civillian
-            Passenger: [ -1, -1 ]
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/cluster.yml
+++ b/Resources/Prototypes/Maps/cluster.yml
@@ -54,7 +54,7 @@
             SalvageSpecialist: [ 2, 2 ]
             CargoTechnician: [ 2, 2 ]
             #civillian
-            Passenger: [ 1, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 1 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/cluster.yml
+++ b/Resources/Prototypes/Maps/cluster.yml
@@ -54,7 +54,7 @@
             SalvageSpecialist: [ 2, 2 ]
             CargoTechnician: [ 2, 2 ]
             #civillian
-            # Passenger: [ -1, -1 ] # Rayten-graytidegate
+            Passenger: [ 0, 0 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/convex.yml
+++ b/Resources/Prototypes/Maps/convex.yml
@@ -55,7 +55,7 @@
             SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 4, 4 ]
             #civilian
-            Passenger: [ 0, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 0 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/convex.yml
+++ b/Resources/Prototypes/Maps/convex.yml
@@ -55,7 +55,7 @@
             SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 4, 4 ]
             #civilian
-            Passenger: [ 1, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 1 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/convex.yml
+++ b/Resources/Prototypes/Maps/convex.yml
@@ -55,7 +55,7 @@
             SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 4, 4 ]
             #civilian
-            Passenger: [ 1, 1 ] # Rayten-graytidegate
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/convex.yml
+++ b/Resources/Prototypes/Maps/convex.yml
@@ -55,7 +55,7 @@
             SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 4, 4 ]
             #civilian
-            Passenger: [ -1, -1 ]
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/convex.yml
+++ b/Resources/Prototypes/Maps/convex.yml
@@ -55,7 +55,7 @@
             SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 4, 4 ]
             #civilian
-            # Passenger: [ -1, -1 ] # Rayten-graytidegate
+            Passenger: [ 0, 0 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/core.yml
+++ b/Resources/Prototypes/Maps/core.yml
@@ -57,7 +57,7 @@
             Quartermaster: [ 1, 1 ]
             SalvageSpecialist: [ 2, 2 ]
             #civilian
-            # Passenger: [ -1, -1 ] # Rayten-graytidegate
+            Passenger: [ 0, 0 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/core.yml
+++ b/Resources/Prototypes/Maps/core.yml
@@ -57,7 +57,7 @@
             Quartermaster: [ 1, 1 ]
             SalvageSpecialist: [ 2, 2 ]
             #civilian
-            Passenger: [ 1, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 1 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/core.yml
+++ b/Resources/Prototypes/Maps/core.yml
@@ -57,7 +57,7 @@
             Quartermaster: [ 1, 1 ]
             SalvageSpecialist: [ 2, 2 ]
             #civilian
-            Passenger: [ 1, 1 ] # Rayten-graytidegate
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/core.yml
+++ b/Resources/Prototypes/Maps/core.yml
@@ -57,7 +57,7 @@
             Quartermaster: [ 1, 1 ]
             SalvageSpecialist: [ 2, 2 ]
             #civilian
-            Passenger: [ 0, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 0 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/core.yml
+++ b/Resources/Prototypes/Maps/core.yml
@@ -57,7 +57,7 @@
             Quartermaster: [ 1, 1 ]
             SalvageSpecialist: [ 2, 2 ]
             #civilian
-            Passenger: [ -1, -1 ]
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/debug.yml
+++ b/Resources/Prototypes/Maps/debug.yml
@@ -11,7 +11,7 @@
           mapNameTemplate: "Empty"
         - type: StationJobs
           availableJobs:
-            Passenger: [ -1, -1 ]
+            ServiceWorker: [ -1, -1 ] # Rayten-graytidegate
 - type: gameMap
   id: Dev
   mapName: Dev

--- a/Resources/Prototypes/Maps/debug.yml
+++ b/Resources/Prototypes/Maps/debug.yml
@@ -11,8 +11,7 @@
           mapNameTemplate: "Empty"
         - type: StationJobs
           availableJobs:
-            # Passenger: [ -1, -1 ] # Rayten-graytidegate
-
+            Passenger: [ -1, -1 ]
 - type: gameMap
   id: Dev
   mapName: Dev

--- a/Resources/Prototypes/Maps/debug.yml
+++ b/Resources/Prototypes/Maps/debug.yml
@@ -11,7 +11,7 @@
           mapNameTemplate: "Empty"
         - type: StationJobs
           availableJobs:
-            Passenger: [ -1, -1 ]
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
 
 - type: gameMap
   id: Dev

--- a/Resources/Prototypes/Maps/elkridge.yml
+++ b/Resources/Prototypes/Maps/elkridge.yml
@@ -59,7 +59,7 @@
             SalvageSpecialist: [ 2, 2 ]
             CargoTechnician: [ 2, 3 ]
             #civilian
-            # Passenger: [ -1, -1 ] # Rayten-graytidegate
+            Passenger: [ 0, 0 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/elkridge.yml
+++ b/Resources/Prototypes/Maps/elkridge.yml
@@ -59,7 +59,7 @@
             SalvageSpecialist: [ 2, 2 ]
             CargoTechnician: [ 2, 3 ]
             #civilian
-            Passenger: [ 1, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 1 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/elkridge.yml
+++ b/Resources/Prototypes/Maps/elkridge.yml
@@ -59,7 +59,7 @@
             SalvageSpecialist: [ 2, 2 ]
             CargoTechnician: [ 2, 3 ]
             #civilian
-            Passenger: [ 1, 1 ] # Rayten-graytidegate
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/elkridge.yml
+++ b/Resources/Prototypes/Maps/elkridge.yml
@@ -59,7 +59,7 @@
             SalvageSpecialist: [ 2, 2 ]
             CargoTechnician: [ 2, 3 ]
             #civilian
-            Passenger: [ 0, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 0 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/elkridge.yml
+++ b/Resources/Prototypes/Maps/elkridge.yml
@@ -59,7 +59,7 @@
             SalvageSpecialist: [ 2, 2 ]
             CargoTechnician: [ 2, 3 ]
             #civilian
-            Passenger: [ -1, -1 ]
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/fland.yml
+++ b/Resources/Prototypes/Maps/fland.yml
@@ -57,7 +57,7 @@
             SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 6, 6 ]
             #civilian
-            Passenger: [ -1, -1 ]
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/fland.yml
+++ b/Resources/Prototypes/Maps/fland.yml
@@ -57,7 +57,7 @@
             SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 6, 6 ]
             #civilian
-            Passenger: [ 1, 1 ] # Rayten-graytidegate
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/fland.yml
+++ b/Resources/Prototypes/Maps/fland.yml
@@ -57,7 +57,7 @@
             SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 6, 6 ]
             #civilian
-            Passenger: [ 1, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 1 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/fland.yml
+++ b/Resources/Prototypes/Maps/fland.yml
@@ -57,7 +57,7 @@
             SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 6, 6 ]
             #civilian
-            # Passenger: [ -1, -1 ] # Rayten-graytidegate
+            Passenger: [ 0, 0 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/fland.yml
+++ b/Resources/Prototypes/Maps/fland.yml
@@ -57,7 +57,7 @@
             SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 6, 6 ]
             #civilian
-            Passenger: [ 0, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 0 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/gate.yml
+++ b/Resources/Prototypes/Maps/gate.yml
@@ -57,7 +57,7 @@
             SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 6, 6 ]
             #civilian
-            Passenger: [ -1, -1 ]
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/gate.yml
+++ b/Resources/Prototypes/Maps/gate.yml
@@ -57,7 +57,7 @@
             SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 6, 6 ]
             #civilian
-            Passenger: [ 1, 1 ] # Rayten-graytidegate
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/gate.yml
+++ b/Resources/Prototypes/Maps/gate.yml
@@ -57,7 +57,7 @@
             SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 6, 6 ]
             #civilian
-            Passenger: [ 1, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 1 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/gate.yml
+++ b/Resources/Prototypes/Maps/gate.yml
@@ -57,7 +57,7 @@
             SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 6, 6 ]
             #civilian
-            # Passenger: [ -1, -1 ] # Rayten-graytidegate
+            Passenger: [ 0, 0 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/gate.yml
+++ b/Resources/Prototypes/Maps/gate.yml
@@ -57,7 +57,7 @@
             SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 6, 6 ]
             #civilian
-            Passenger: [ 0, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 0 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/loop.yml
+++ b/Resources/Prototypes/Maps/loop.yml
@@ -57,7 +57,7 @@
             SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 4, 4 ]
             #civilian
-            Passenger: [ 0, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 0 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/loop.yml
+++ b/Resources/Prototypes/Maps/loop.yml
@@ -57,7 +57,7 @@
             SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 4, 4 ]
             #civilian
-            Passenger: [ -1, -1 ]
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/loop.yml
+++ b/Resources/Prototypes/Maps/loop.yml
@@ -57,7 +57,7 @@
             SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 4, 4 ]
             #civilian
-            Passenger: [ 1, 1 ] # Rayten-graytidegate
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/loop.yml
+++ b/Resources/Prototypes/Maps/loop.yml
@@ -57,7 +57,7 @@
             SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 4, 4 ]
             #civilian
-            Passenger: [ 1, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 1 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/loop.yml
+++ b/Resources/Prototypes/Maps/loop.yml
@@ -57,7 +57,7 @@
             SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 4, 4 ]
             #civilian
-            # Passenger: [ -1, -1 ] # Rayten-graytidegate
+            Passenger: [ 0, 0 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/marathon.yml
+++ b/Resources/Prototypes/Maps/marathon.yml
@@ -58,7 +58,7 @@
             SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 3, 3 ]
             #civilian
-            Passenger: [ 0, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 0 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/marathon.yml
+++ b/Resources/Prototypes/Maps/marathon.yml
@@ -58,7 +58,7 @@
             SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 3, 3 ]
             #civilian
-            Passenger: [ 1, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 1 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/marathon.yml
+++ b/Resources/Prototypes/Maps/marathon.yml
@@ -58,7 +58,7 @@
             SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 3, 3 ]
             #civilian
-            # Passenger: [ -1, -1 ] # Rayten-graytidegate
+            Passenger: [ 0, 0 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/marathon.yml
+++ b/Resources/Prototypes/Maps/marathon.yml
@@ -58,7 +58,7 @@
             SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 3, 3 ]
             #civilian
-            Passenger: [ 1, 1 ] # Rayten-graytidegate
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/marathon.yml
+++ b/Resources/Prototypes/Maps/marathon.yml
@@ -58,7 +58,7 @@
             SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 3, 3 ]
             #civilian
-            Passenger: [ -1, -1 ]
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/meta.yml
+++ b/Resources/Prototypes/Maps/meta.yml
@@ -58,7 +58,7 @@
             SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 4, 6 ]
             #civilian (3+)
-            Passenger: [ -1, -1 ]
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/meta.yml
+++ b/Resources/Prototypes/Maps/meta.yml
@@ -58,7 +58,7 @@
             SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 4, 6 ]
             #civilian (3+)
-            # Passenger: [ -1, -1 ] # Rayten-graytidegate
+            Passenger: [ 0, 0 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/meta.yml
+++ b/Resources/Prototypes/Maps/meta.yml
@@ -58,7 +58,7 @@
             SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 4, 6 ]
             #civilian (3+)
-            Passenger: [ 0, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 0 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/meta.yml
+++ b/Resources/Prototypes/Maps/meta.yml
@@ -58,7 +58,7 @@
             SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 4, 6 ]
             #civilian (3+)
-            Passenger: [ 1, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 1 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/meta.yml
+++ b/Resources/Prototypes/Maps/meta.yml
@@ -58,7 +58,7 @@
             SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 4, 6 ]
             #civilian (3+)
-            Passenger: [ 1, 1 ] # Rayten-graytidegate
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/oasis.yml
+++ b/Resources/Prototypes/Maps/oasis.yml
@@ -59,7 +59,7 @@
             SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 4, 4 ]
             #civilian
-            Passenger: [ 0, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 0 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/oasis.yml
+++ b/Resources/Prototypes/Maps/oasis.yml
@@ -59,7 +59,7 @@
             SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 4, 4 ]
             #civilian
-            Passenger: [ 1, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 1 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/oasis.yml
+++ b/Resources/Prototypes/Maps/oasis.yml
@@ -59,7 +59,7 @@
             SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 4, 4 ]
             #civilian
-            # Passenger: [ -1, -1 ] # Rayten-graytidegate
+            Passenger: [ 0, 0 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/oasis.yml
+++ b/Resources/Prototypes/Maps/oasis.yml
@@ -59,7 +59,7 @@
             SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 4, 4 ]
             #civilian
-            Passenger: [ 1, 1 ] # Rayten-graytidegate
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/oasis.yml
+++ b/Resources/Prototypes/Maps/oasis.yml
@@ -59,7 +59,7 @@
             SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 4, 4 ]
             #civilian
-            Passenger: [ -1, -1 ]
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/omega.yml
+++ b/Resources/Prototypes/Maps/omega.yml
@@ -57,7 +57,7 @@
             SalvageSpecialist: [ 2, 2 ]
             CargoTechnician: [ 2, 2 ]
             #civilian
-            Passenger: [ 1, 1 ] # Rayten-graytidegate
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/omega.yml
+++ b/Resources/Prototypes/Maps/omega.yml
@@ -57,7 +57,7 @@
             SalvageSpecialist: [ 2, 2 ]
             CargoTechnician: [ 2, 2 ]
             #civilian
-            # Passenger: [ -1, -1 ] # Rayten-graytidegate
+            Passenger: [ 0, 0 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/omega.yml
+++ b/Resources/Prototypes/Maps/omega.yml
@@ -57,7 +57,7 @@
             SalvageSpecialist: [ 2, 2 ]
             CargoTechnician: [ 2, 2 ]
             #civilian
-            Passenger: [ 1, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 1 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/omega.yml
+++ b/Resources/Prototypes/Maps/omega.yml
@@ -57,7 +57,7 @@
             SalvageSpecialist: [ 2, 2 ]
             CargoTechnician: [ 2, 2 ]
             #civilian
-            Passenger: [ -1, -1 ]
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/omega.yml
+++ b/Resources/Prototypes/Maps/omega.yml
@@ -57,7 +57,7 @@
             SalvageSpecialist: [ 2, 2 ]
             CargoTechnician: [ 2, 2 ]
             #civilian
-            Passenger: [ 0, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 0 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/packed.yml
+++ b/Resources/Prototypes/Maps/packed.yml
@@ -57,7 +57,7 @@
             SalvageSpecialist: [ 2, 2 ]
             CargoTechnician: [ 2, 2 ]
             #civilian
-            Passenger: [ 1, 1 ] # Rayten-graytidegate
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/packed.yml
+++ b/Resources/Prototypes/Maps/packed.yml
@@ -57,7 +57,7 @@
             SalvageSpecialist: [ 2, 2 ]
             CargoTechnician: [ 2, 2 ]
             #civilian
-            # Passenger: [ -1, -1 ] # Rayten-graytidegate
+            Passenger: [ 0, 0 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/packed.yml
+++ b/Resources/Prototypes/Maps/packed.yml
@@ -57,7 +57,7 @@
             SalvageSpecialist: [ 2, 2 ]
             CargoTechnician: [ 2, 2 ]
             #civilian
-            Passenger: [ 1, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 1 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/packed.yml
+++ b/Resources/Prototypes/Maps/packed.yml
@@ -57,7 +57,7 @@
             SalvageSpecialist: [ 2, 2 ]
             CargoTechnician: [ 2, 2 ]
             #civilian
-            Passenger: [ -1, -1 ]
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/packed.yml
+++ b/Resources/Prototypes/Maps/packed.yml
@@ -57,7 +57,7 @@
             SalvageSpecialist: [ 2, 2 ]
             CargoTechnician: [ 2, 2 ]
             #civilian
-            Passenger: [ 0, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 0 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/plasma.yml
+++ b/Resources/Prototypes/Maps/plasma.yml
@@ -65,4 +65,4 @@
             SalvageSpecialist: [ 4, 4 ]
             CargoTechnician: [ 4, 6 ]
             #civilian - the tiders yearn for the mines
-            Passenger: [ 0, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 0 ] # Rayten-graytidegate

--- a/Resources/Prototypes/Maps/plasma.yml
+++ b/Resources/Prototypes/Maps/plasma.yml
@@ -65,4 +65,4 @@
             SalvageSpecialist: [ 4, 4 ]
             CargoTechnician: [ 4, 6 ]
             #civilian - the tiders yearn for the mines
-            Passenger: [ 1, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 1 ] # Rayten-graytidegate

--- a/Resources/Prototypes/Maps/plasma.yml
+++ b/Resources/Prototypes/Maps/plasma.yml
@@ -65,4 +65,4 @@
             SalvageSpecialist: [ 4, 4 ]
             CargoTechnician: [ 4, 6 ]
             #civilian - the tiders yearn for the mines
-            Passenger: [ 1, 1 ] # Rayten-graytidegate
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate

--- a/Resources/Prototypes/Maps/plasma.yml
+++ b/Resources/Prototypes/Maps/plasma.yml
@@ -65,4 +65,4 @@
             SalvageSpecialist: [ 4, 4 ]
             CargoTechnician: [ 4, 6 ]
             #civilian - the tiders yearn for the mines
-            Passenger: [ -1, -1 ]
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate

--- a/Resources/Prototypes/Maps/plasma.yml
+++ b/Resources/Prototypes/Maps/plasma.yml
@@ -65,4 +65,4 @@
             SalvageSpecialist: [ 4, 4 ]
             CargoTechnician: [ 4, 6 ]
             #civilian - the tiders yearn for the mines
-            # Passenger: [ -1, -1 ] # Rayten-graytidegate
+            Passenger: [ 0, 0 ] # Rayten-graytidegate

--- a/Resources/Prototypes/Maps/reach.yml
+++ b/Resources/Prototypes/Maps/reach.yml
@@ -32,5 +32,5 @@
             AtmosphericTechnician: [ 1, 1 ]
             StationEngineer: [ 1, 2 ]
             Scientist: [ 1, 1 ]
-            Passenger: [ 1, 1 ] # Rayten-graytidegate
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
 

--- a/Resources/Prototypes/Maps/reach.yml
+++ b/Resources/Prototypes/Maps/reach.yml
@@ -32,5 +32,5 @@
             AtmosphericTechnician: [ 1, 1 ]
             StationEngineer: [ 1, 2 ]
             Scientist: [ 1, 1 ]
-            Passenger: [ 1, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 1 ] # Rayten-graytidegate
 

--- a/Resources/Prototypes/Maps/reach.yml
+++ b/Resources/Prototypes/Maps/reach.yml
@@ -32,5 +32,5 @@
             AtmosphericTechnician: [ 1, 1 ]
             StationEngineer: [ 1, 2 ]
             Scientist: [ 1, 1 ]
-            Passenger: [ 0, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 0 ] # Rayten-graytidegate
 

--- a/Resources/Prototypes/Maps/reach.yml
+++ b/Resources/Prototypes/Maps/reach.yml
@@ -32,5 +32,5 @@
             AtmosphericTechnician: [ 1, 1 ]
             StationEngineer: [ 1, 2 ]
             Scientist: [ 1, 1 ]
-            Passenger: [ -1, -1 ]
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
 

--- a/Resources/Prototypes/Maps/reach.yml
+++ b/Resources/Prototypes/Maps/reach.yml
@@ -32,5 +32,5 @@
             AtmosphericTechnician: [ 1, 1 ]
             StationEngineer: [ 1, 2 ]
             Scientist: [ 1, 1 ]
-            # Passenger: [ -1, -1 ] # Rayten-graytidegate
+            Passenger: [ 0, 0 ] # Rayten-graytidegate
 

--- a/Resources/Prototypes/Maps/relic.yml
+++ b/Resources/Prototypes/Maps/relic.yml
@@ -58,7 +58,7 @@
             Quartermaster: [ 1, 1 ]
             CargoTechnician: [ 2, 2 ]
             #civilian
-            Passenger: [ 1, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 1 ] # Rayten-graytidegate
             #silicon
             StationAi: [ 1, 1 ]
             Borg: [ 2, 2 ]

--- a/Resources/Prototypes/Maps/relic.yml
+++ b/Resources/Prototypes/Maps/relic.yml
@@ -58,7 +58,7 @@
             Quartermaster: [ 1, 1 ]
             CargoTechnician: [ 2, 2 ]
             #civilian
-            # Passenger: [ -1, -1 ] # Rayten-graytidegate
+            Passenger: [ 0, 0 ] # Rayten-graytidegate
             #silicon
             StationAi: [ 1, 1 ]
             Borg: [ 2, 2 ]

--- a/Resources/Prototypes/Maps/relic.yml
+++ b/Resources/Prototypes/Maps/relic.yml
@@ -58,7 +58,7 @@
             Quartermaster: [ 1, 1 ]
             CargoTechnician: [ 2, 2 ]
             #civilian
-            Passenger: [ 1, 1 ] # Rayten-graytidegate
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             #silicon
             StationAi: [ 1, 1 ]
             Borg: [ 2, 2 ]

--- a/Resources/Prototypes/Maps/relic.yml
+++ b/Resources/Prototypes/Maps/relic.yml
@@ -58,7 +58,7 @@
             Quartermaster: [ 1, 1 ]
             CargoTechnician: [ 2, 2 ]
             #civilian
-            Passenger: [ -1, -1 ]
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             #silicon
             StationAi: [ 1, 1 ]
             Borg: [ 2, 2 ]

--- a/Resources/Prototypes/Maps/relic.yml
+++ b/Resources/Prototypes/Maps/relic.yml
@@ -58,7 +58,7 @@
             Quartermaster: [ 1, 1 ]
             CargoTechnician: [ 2, 2 ]
             #civilian
-            Passenger: [ 0, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 0 ] # Rayten-graytidegate
             #silicon
             StationAi: [ 1, 1 ]
             Borg: [ 2, 2 ]

--- a/Resources/Prototypes/Maps/saltern.yml
+++ b/Resources/Prototypes/Maps/saltern.yml
@@ -57,7 +57,7 @@
             SalvageSpecialist: [ 1, 3 ]
             CargoTechnician: [ 2, 2 ]
             #civillian
-            # Passenger: [ -1, -1 ] # Rayten-graytidegate
+            Passenger: [ 0, 0 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/saltern.yml
+++ b/Resources/Prototypes/Maps/saltern.yml
@@ -57,7 +57,7 @@
             SalvageSpecialist: [ 1, 3 ]
             CargoTechnician: [ 2, 2 ]
             #civillian
-            Passenger: [ -1, -1 ]
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/saltern.yml
+++ b/Resources/Prototypes/Maps/saltern.yml
@@ -57,7 +57,7 @@
             SalvageSpecialist: [ 1, 3 ]
             CargoTechnician: [ 2, 2 ]
             #civillian
-            Passenger: [ 0, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 0 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/saltern.yml
+++ b/Resources/Prototypes/Maps/saltern.yml
@@ -57,7 +57,7 @@
             SalvageSpecialist: [ 1, 3 ]
             CargoTechnician: [ 2, 2 ]
             #civillian
-            Passenger: [ 1, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 1 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/saltern.yml
+++ b/Resources/Prototypes/Maps/saltern.yml
@@ -57,7 +57,7 @@
             SalvageSpecialist: [ 1, 3 ]
             CargoTechnician: [ 2, 2 ]
             #civillian
-            Passenger: [ 1, 1 ] # Rayten-graytidegate
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/train.yml
+++ b/Resources/Prototypes/Maps/train.yml
@@ -59,7 +59,7 @@
             SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 3, 3 ]
             #civilian
-            Passenger: [ 0, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 0 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/train.yml
+++ b/Resources/Prototypes/Maps/train.yml
@@ -59,7 +59,7 @@
             SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 3, 3 ]
             #civilian
-            Passenger: [ 1, 0 ] # Rayten-graytidegate
+            Passenger: [ 1, 1 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/train.yml
+++ b/Resources/Prototypes/Maps/train.yml
@@ -59,7 +59,7 @@
             SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 3, 3 ]
             #civilian
-            Passenger: [ 1, 1 ] # Rayten-graytidegate
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/train.yml
+++ b/Resources/Prototypes/Maps/train.yml
@@ -59,7 +59,7 @@
             SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 3, 3 ]
             #civilian
-            Passenger: [ -1, -1 ]
+            # Passenger: [ -1, -1 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/train.yml
+++ b/Resources/Prototypes/Maps/train.yml
@@ -59,7 +59,7 @@
             SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 3, 3 ]
             #civilian
-            # Passenger: [ -1, -1 ] # Rayten-graytidegate
+            Passenger: [ 0, 0 ] # Rayten-graytidegate
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 1, 1 ]

--- a/Resources/Prototypes/Roles/Jobs/Civilian/assistant.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/assistant.yml
@@ -1,6 +1,7 @@
 - type: job
   id: Passenger
   name: job-name-passenger
+  setPreference: false # Rayten-graytidegate
   description: job-description-passenger
   playTimeTracker: JobPassenger
   startingGear: PassengerGear

--- a/Resources/Prototypes/Roles/Jobs/departments.yml
+++ b/Resources/Prototypes/Roles/Jobs/departments.yml
@@ -27,7 +27,7 @@
   - Librarian
   - Mime
   - Musician
-  - Passenger
+  # - Passenger  # Rayten-graytidegate
   - Reporter
   - Visitor
   - Zookeeper


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
Роль пассажиров полностью удалена отовсюду

# Почему стоит удалить пассажиров из игры?
### 1. Низкий уровень ролевой игры (Low RP)
Пассажиры чаще всего либо бесцельно бродят по станции, либо ведут себя деструктивно (гриферят, мешают работе экипажа). В отличие от других профессий, у них нет ни обязанностей, ни мотивации для взаимодействия с командой. В результате они либо игнорируют RP, либо превращаются в «мебель» на фоне основного геймплея.

### 2. Нелогичность в сеттинге научно-исследовательской станции
Станция — это не круизный лайнер и не общественный транспорт. Это опасный научно-технический объект, куда не пускают случайных людей. Нет никакого правдоподобного объяснения, почему там оказались гражданские без конкретных задач. Даже если предположить, что это «гости корпорации», у них должна быть какая-то роль (наблюдатели, инспекторы, журналисты), а не просто «пассажир».

### 3. Соло-роль без взаимодействия с другими
Пассажиры не встроены в игровые циклы:

У них нет задач, которые требовали бы кооперации.

Они не зависят от других игроков и никак не влияют на их геймплей.

В лучшем случае они просто стоят в баре, в худшем — мешают работе или устраивают хаос.

Если роль не способствует социализации и командной игре, зачем она вообще нужна?


**Список изменений**
- remove: Пассажиры удалены //test
