### PR TITLE
склетные реворки

### DIFF
--- a/Content.Server/Vanilla/Background/misc/SkeletonCurse/SkeletonCurseComponent.cs
+++ b/Content.Server/Vanilla/Background/misc/SkeletonCurse/SkeletonCurseComponent.cs
@@ -14,7 +14,7 @@ public sealed partial class SkeletonCurseComponent : Component
     {
         DamageDict = new()
         {
-            { "Blunt", 1200 }
+            { "Blunt", 105 }
         }
     };
 

--- a/Resources/Prototypes/Vanilla/Backgrounds/ghostroles/ClosetSkeletonBackgrounds.yml
+++ b/Resources/Prototypes/Vanilla/Backgrounds/ghostroles/ClosetSkeletonBackgrounds.yml
@@ -7,7 +7,7 @@
   - ClosetSkeletonWizardBackground
   - ClosetSkeletonEvilBackground
   - ClosetSkeletonCurseBackground
-  - ClosetSkeletonSaboteurBackground
+  # - ClosetSkeletonSaboteurBackground
 
 - type: Background
   id: ClosetSkeletonBrainlessBackground

--- a/Resources/Prototypes/Vanilla/Polymorphs/polymorph.yml
+++ b/Resources/Prototypes/Vanilla/Polymorphs/polymorph.yml
@@ -1,0 +1,15 @@
+- type: polymorph
+  id: CursedSkeleton
+  configuration:
+    entity: MobSkeletonPerson
+    forced: true
+    inventory: Drop
+    transferName: true
+    transferDamage: true
+    revertOnCrit: false
+    revertOnDeath: true
+    polymorphSound: !type:SoundPathSpecifier
+      path: /Audio/Misc/narsie_rises.ogg
+    exitPolymorphSound: !type:SoundPathSpecifier
+      path: /Audio/Misc/narsie_rises.ogg
+    polymorphPopup: SkeletonCurse-popup


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
Изменения скелета;
теперь есть всего три антажные предыстории
1. Проклятый скелет
2. Скелет через рдм
3. Скелет-маг
Предыстория скелета-саботёра удалена до реворка
Проклятие от проклятого скелета теперь более "щадящее" в том смысле что вы превратитесь обратно если умрёте.
## Почему / Баланс
В общем, теперь скелеты-антаги неразумны, а скелеты-добряки разумны, это позволяет моментально отличить скелета, которого следует убить на месте от скелета, которому стоит дать шанс пожить.
Нужно это для уменьшения рдмности этой роли, она теперь более очевидна - теперь можно сразу понять кто перед тобой - друг или враг. 

**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
Убедитесь, что вы прочитали рекомендации и вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->
<!--
:cl:
- tweak: Теперь получив проклятье от проклятого скелета можно умереть и вы превратитесь обратно в себя, но если вас убьют, то проклятие перенесётся на вашего убийцу. В конечном итоге получив проклятие вам нужно как-либо самоубиться по рп. 
- remove: Времено удалена предыстория скелета-саботёра до реворка
