### PR TITLE
Связь-с-цк апдейт

### DIFF
--- a/Content.Shared/Fax/Components/FaxMachineComponent.cs
+++ b/Content.Shared/Fax/Components/FaxMachineComponent.cs
@@ -149,8 +149,33 @@ public sealed partial class FaxMachineComponent : Component
     /// </summary>
     [DataField]
     public EntProtoId PrintOfficePaperId = "PaperOffice";
+
+    ///RAYTEN-START
+    [DataField]
+    public List<FaxInBlueSpace> FaxesInBlueSpace = new();
+
+    [ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
+    public bool SpamFilter { get; set; } = false;
 }
 
+public sealed class FaxInBlueSpace
+{
+    public EntityUid FaxUid;
+    public FaxPrintout Printout;
+    public string? FromAddress;
+    public TimeSpan TimeRemaining;
+
+    public FaxInBlueSpace(EntityUid faxUid, FaxPrintout printout, string? fromAddress, TimeSpan timeRemaining)
+    {
+        FaxUid = faxUid;
+        Printout = printout;
+        FromAddress = fromAddress;
+        TimeRemaining = timeRemaining;
+    }
+}
+
+    /// RAYTEN-END
 [DataDefinition]
 public sealed partial class FaxPrintout
 {

--- a/Resources/Prototypes/Entities/Structures/Machines/fax_machine.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/fax_machine.yml
@@ -85,8 +85,9 @@
         map: [ "base" ]
         color: "#bfe3ff"
   - type: FaxMachine
-    name: "Central Command"
+    name: "Центральное командование" #RAYTEN - LOCALE
     notifyAdmins: true
+    spamFilter: true # RAYTEN - BLUESPACEFAX
     receiveAllStationGoals: true # Corvax-StationGoal
 
 - type: entity


### PR DESCRIPTION
# Связь-с-цк апдейт.
Апдейт нацелен на уменьшение влияния центкома на станцию и увеличение «самостоятельности» станции.
А также на уменьшение влияния админов на ход раунда
## Связь
1. С помощью красного телефона и кроваво-красного телефона больше нельзя связаться с админами, факс - единственная возможность. (Ну и алтари, бананафон, но там богиня-хонкоматерь)
2. Факсы теперь имеют «время на доставку» в 5 минут, если находятся в разных секторах.

3. Теперь глушилка блокирует возможность работать с факсами вообще
4. Документы без печати теперь не доставляются на цк, НТ установило спам-фильтр! 
## Прочее
1. Теперь можно вызвать обр на консоли связи, для этого нужен доступ капитана и нажать на кнопку. Собственно.
2. Для вызова/отзыва эвака теперь нужен доступ капитана
3. Для досрочной эвакуации нужен доступ капитана, теперь достаточно одного голоса для досрочной эвакуации. 
## ОБР
1. Теперь если капитан вызывает обр - он будет моментально заспавнен на **верфи дсо**, у гостов будет где-то минут 10 на вооружение, т.к. шаттл будет заблокирован эти 10 минут; по истечении 10 минут собственно обр сможет прийти и дать пизды плохишам.

2. Откат разных групп обр, теперь обр делится на два вида - обр и рхбзз.

3. Смерть обр приводит к концу раунда (поражение экипажа/контроль над объектом считается утерянным).
3.1. При чем не важно, жив ли экипаж или нет, живы ли антаги или нет; если обр умерли - нт разрывает контракт со станцией.

4. Изменены часы на роли обр и появились собствено роли обр!
4.1. Командир обр - 10 часов на командовании, 10 часов на сб
4.2. Оперативник обр - 10 часов на отделе сб
4.3. медик обр - 10 часов на мед отделе
4.4. инж обр - 10 часов на инж отделе
4.5. все роли требуют 100 часов общего времени

5. Если стоит режим зомби - вместо обр будет отправлен рхбзз
5.1. командир рхбзз - 10 часов ком, 10 часов сб
5.2. Оперативник рхбзз - 10 часов сб

6. Дедсквад часов не требует, ну а че там сложного то собственно.
6.1. У дедсквада появился локатор сердцебиения, который как пинпоинтер будет указывать на всех живых челиксов
6.2. Во время эпсилон-кода будет автоматически выстреливаться бса по всем, кто не имеет скафандра дедсквада и кто находится не на гриде станции (в космосе, на шаттле карго, …)

## Глушилка
1. Длительность глушилок уменьшена - у яо до 20 минут, у мага и лонопса до 10 минут, нулевые и революционеры теперь устанавливают глушилку на 1 час.
2. Глушилки теперь также блокируют факсы и возможность вызова обр (вроде я уже это говорил?)
**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
Убедитесь, что вы прочитали рекомендации и вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->
<!--
:cl:
- add: Добавлено веселье!
- remove: Удалено веселье!
- tweak: Изменено веселье!
- fix: Исправлено веселье!
-->
