### PR TITLE
Изменения унатхов

### DIFF
--- a/Content.Shared/Vanilla/Entities/NightVision/NightVisionComponent.cs
+++ b/Content.Shared/Vanilla/Entities/NightVision/NightVisionComponent.cs
@@ -1,0 +1,8 @@
+namespace Content.Shared.Vanilla.Entities.NightVision;
+
+[RegisterComponent]
+public sealed partial class NightVisionComponent : Component
+{
+    [DataField("enabled")]
+    public bool Enabled = true;
+}

--- a/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
@@ -95,7 +95,13 @@
             sprite: Corvax/Mobs/Species/displacement.rsi
             state: shoes
     # Corvax-Displacements-End
-
+    # Rayten-NightVision-start (ночное зрение для унатхов; зелёные оттенки в радиусе 6 тайлов)
+  - type: NightVision 
+  - type: PointLight
+    radius: 9
+    color: "#013220"
+    enabled: false
+    # Rayten-end
 - type: entity
   parent: BaseSpeciesDummy
   id: MobReptilianDummy

--- a/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
@@ -95,13 +95,23 @@
             sprite: Corvax/Mobs/Species/displacement.rsi
             state: shoes
     # Corvax-Displacements-End
-    # Rayten-NightVision-start (ночное зрение для унатхов; зелёные оттенки в радиусе 6 тайлов)
+    # Rayten-start
   - type: NightVision 
   - type: PointLight
     radius: 9
     color: "#013220"
     enabled: false
+  - type: PassiveDamage
+    allowedStates:
+    - Alive
+    damageCap: 60
+    damage:
+      types:
+        Heat: -0.14
+      groups:
+        Brute: -0.28
     # Rayten-end
+
 - type: entity
   parent: BaseSpeciesDummy
   id: MobReptilianDummy


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
### Ночное зрение у унатхов
Унатхи теперь видят в радиусе **9 тайлов** даже в полной темноте, что значительно облегчает ориентирование и охоту на мышей.
| Описание                                | Изображение                                                     |
|----------------------------------------|----------------------------------------------------------------|
| 1. Обычное зрение в нормальном свете   | <img src="https://github.com/user-attachments/assets/0fa3e02f-1a77-4442-9e8d-d37fc77cdb9a" width="660" /> |
| 2. Зрение унатха в нормальном свете    | <img src="https://github.com/user-attachments/assets/44754e65-e8f6-46f5-b515-49327b45120a" width="660" /> |
| 3. Обычное зрение в кромешной тьме     | <img src="https://github.com/user-attachments/assets/ab059a74-5d4b-47c4-94af-eac9190a4d4e" width="660" /> |
| 4. Зрение унатха в кромешной тьме      | <img src="https://github.com/user-attachments/assets/eec99f3f-9a23-4f25-a3cc-7ff6f4bad14a" width="660" /> |

### Регенерация у унатхов 🦎✨

Поскольку унатхи — рептилии, у них **повышенная регенерация**, которая работает сильнее, чем у других рас:

| Параметр                 | Значение для унатхов | Значение для остальных рас |
|--------------------------|----------------------|----------------------------|
| Значение регенарции    |  **0.1** урона для тупых, режущих, колющих, 0.7 для ожогов              | **0.03** урона для тупых, режущих, колющих, 0.7 для ожогов                         |
| Порог общего урона, при котором действует регенерация | **< 60**              | < 20                       |


**Список изменений**

:cl:
- add: Унатхам добавлено ночное зрение
- add: Унатхам добавлена повышенная регенерация хп
