### PR TITLE
[Maps][hotfix] Fix maps for tdm

### DIFF
--- a/Resources/Maps/Vanilla/Misc/TTT/TTT_Mine.yml
+++ b/Resources/Maps/Vanilla/Misc/TTT/TTT_Mine.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 266.0.0
   forkId: ""
   forkVersion: ""
-  time: 09/19/2025 14:00:22
-  entityCount: 1371
+  time: 09/21/2025 18:47:05
+  entityCount: 1375
 maps:
 - 1
 grids:
@@ -95,8 +95,6 @@ entities:
       bodyType: Dynamic
     - type: Fixtures
       fixtures: {}
-    - type: BecomesStation
-      id: Mine
     - type: OccluderTree
     - type: SpreaderGrid
     - type: Shuttle
@@ -4480,6 +4478,16 @@ entities:
     - type: Transform
       pos: 5.5,-9.5
       parent: 3
+  - uid: 1372
+    components:
+    - type: Transform
+      pos: -6.5,5.5
+      parent: 3
+  - uid: 1373
+    components:
+    - type: Transform
+      pos: -5.5,5.5
+      parent: 3
 - proto: SpawnPointTeamRed
   entities:
   - uid: 847
@@ -4521,6 +4529,16 @@ entities:
     components:
     - type: Transform
       pos: 24.5,3.5
+      parent: 3
+  - uid: 1374
+    components:
+    - type: Transform
+      pos: 25.5,-0.5
+      parent: 3
+  - uid: 1375
+    components:
+    - type: Transform
+      pos: 25.5,-2.5
       parent: 3
 - proto: Spoon
   entities:

--- a/Resources/Maps/Vanilla/Misc/TTT/TTT_RickAndMorty.yml
+++ b/Resources/Maps/Vanilla/Misc/TTT/TTT_RickAndMorty.yml
@@ -4,7 +4,7 @@ meta:
   engineVersion: 266.0.0
   forkId: ""
   forkVersion: ""
-  time: 09/19/2025 14:02:16
+  time: 09/21/2025 18:48:28
   entityCount: 1082
 maps:
 - 217
@@ -96,8 +96,6 @@ entities:
       bodyType: Dynamic
     - type: Fixtures
       fixtures: {}
-    - type: BecomesStation
-      id: RickAndMorty
     - type: OccluderTree
     - type: SpreaderGrid
     - type: Shuttle
@@ -5661,17 +5659,17 @@ entities:
   - uid: 697
     components:
     - type: Transform
-      pos: 32.5,17.5
+      pos: 32.5,12.5
       parent: 1
   - uid: 698
     components:
     - type: Transform
-      pos: 33.5,17.5
+      pos: 13.5,11.5
       parent: 1
   - uid: 699
     components:
     - type: Transform
-      pos: 9.5,16.5
+      pos: 33.5,12.5
       parent: 1
 - proto: StairStage
   entities:

--- a/Resources/Prototypes/Vanilla/TDM_Arenas.yml
+++ b/Resources/Prototypes/Vanilla/TDM_Arenas.yml
@@ -10,12 +10,12 @@
 
 - type: TDMMap
   id: Mine
-  arena: Maps/Vanilla/Misc/TDM/Mine.yml
+  arena: Maps/Vanilla/Misc/TTT/TTT_Mine.yml
   arenaparty: 20
 
 - type: TDMMap
   id: RickAndMorty
-  arena: Maps/Vanilla/Misc/TDM/RickAndMorty.yml
+  arena: Maps/Vanilla/Misc/TTT/TTT_RickAndMorty.yml
   arenaparty: 20
 
 # - type: TDMMap


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
<!-- Что вы изменили? -->
В тдме выбирается только NightHouse.
Я чуть-чуть лоханулся. Исправил. 
Поменял места у спавнов, чтобы было баланснее, я не знаю.
## Технические детали
<!-- Краткое описание изменений в коде для облегчения проверки. -->
Убрал у карт - type: BecomesStation id:  ибо возможно оно не даёт их выбрать для тдма. Но это не точно.
Поменял букву в названии офиса, которую изначально не заметил. Закинул карты в другую папку, ибо так думаю правильнее.
